### PR TITLE
use `CMD` instead of `ENTRYPOINT`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ COPY workflow /usr/local/bin
 # execute post-run script
 COPY post-run.sh /tmp
 
-ENTRYPOINT [ "/tmp/post-run.sh" ]
+CMD [ "/tmp/post-run.sh" ]


### PR DESCRIPTION
Because Github's [actions/runner](https://github.com/actions) keeps overriding the entry point defined in `Dockerfile`.