### PR TITLE
make `post-run` script optional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,7 @@ ENV TMPDIR=$TMPDIR
 
 RUN mkdir $TMPDIR
 
+# copy executables to bin directory
 COPY workflow /usr/local/bin
 
-# execute post-run script
-COPY post-run.sh /tmp
-
-CMD [ "/tmp/post-run.sh" ]
+COPY post-run.sh /usr/local/bin

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ jobs:
       env:
         TMPDIR: ${{ env.TMPDIR }}
     steps:
+      - name: execute post-run # to update OS packages and install dependencies.
+        run: post-run.sh
       - name: Clone project # clone a repository to process
         uses: actions/checkout@v3
       - name: Strip files


### PR DESCRIPTION
#62 approach simply did not work because of the format of ENTRYPOINT the runner uses, so now `post-run` should be ran as an action step instead.