### PR TITLE
move installation commands to `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,13 @@ FROM debian:stable
 RUN apt update
 
 # install packages
-RUN apt install sudo curl zip -y
+RUN apt install sudo curl zip imagemagick -y
 
 # install Node.js
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash && apt install nodejs -y
+
+# install markdown-to-document
+RUN npm i markdown-to-document@"<1.0.0" -g
 
 # create a temporary directory for processing and storing files and set it as ENV
 ARG TMPDIR="/tmp/temporary-dir"

--- a/post-run.sh
+++ b/post-run.sh
@@ -1,10 +1,4 @@
 #!/usr/bin/env bash
 
-# Update OS packages
+# update OS packages
 sudo apt update && apt upgrade -y
-
-# Install ImageMagick
-sudo apt install imagemagick -y
-
-# install markdown-to-document
-npm i markdown-to-document@"<1.0.0" -g


### PR DESCRIPTION
Now most installations are handeled in Dockerfile, `post-run.sh` should be used to ensure that packages and dependencies are up-to-date.