### PR TITLE
Fix `dir-zip` by checking if directory exists beforehand

### DIFF
--- a/workflow/dir-zip.sh
+++ b/workflow/dir-zip.sh
@@ -3,15 +3,17 @@
 # Zips a directory.
 
 function usage {
-  echo "usage: $0 <source_directory> <target_path>"
+  echo "usage: $0 <source_directory> <target_path> <output_filename>"
 }
 
-if [[ -z "${1}" || -z "${2}" ]]; then
+if [[ -z "${1}" || -z "${2}" || -z "${3}" ]]; then
   printf '%s\n' "Invalid CLI arguments" >&2
   usage
   exit 1;
 fi
 
-mkdir -p $TMPDIR/$2
+if [ ! -d $2 ]; then
+  mkdir -p $2
+fi
 
-zip -r $TMPDIR/$2 $1
+zip -r $2/$3 $1


### PR DESCRIPTION
- Split up the path and filename into seperate arguments.
- Create the path using `mkdir -p` in case it doesn't exist.