### PR TITLE
Make $RUSTPUP_PATH absolute to avoid issues with Github Actions

### DIFF
--- a/features.sh
+++ b/features.sh
@@ -12,7 +12,7 @@ apt install sudo curl procps build-essential -y
 curl -fsSL https://deb.nodesource.com/setup_16.x | bash && apt install nodejs -y
 
 # Install Rustup
-RUSTPUP_PATH=~/.cargo/env
+RUSTPUP_PATH=/root/.cargo/env
 
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 


### PR DESCRIPTION
Attempt to fix #105.